### PR TITLE
Add github image compression action

### DIFF
--- a/.github/calibre/image-actions.yml
+++ b/.github/calibre/image-actions.yml
@@ -1,0 +1,9 @@
+# https://github.com/marketplace/actions/image-actions
+jpeg:
+  quality: 80
+png:
+  quality: 100
+webp:
+  quality: 80
+ignorePaths:
+  - "node_modules/**"

--- a/.github/workflows/image-action.yml
+++ b/.github/workflows/image-action.yml
@@ -1,0 +1,15 @@
+# https://github.com/marketplace/actions/image-actions
+name: Compress images
+
+on: pull_request
+
+jobs:
+  build:
+    name: calibreapp/image-actions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: calibreapp/image-actions
+        uses: docker://calibreapp/github-image-actions
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
relates to https://github.com/wuhan2020/wuhan2020.github.io/pull/47

Add image compression to compress the images (which improves the static asset serving).

