### PR TITLE
Use official virus names to avoid discrimination

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ### 志愿者入口        >>> [![点击加入 Slack 交流群组](https://img.shields.io/badge/slack-join-orange.svg)](https://join.slack.com/t/wuhan2020/shared_invite/enQtOTQxMTU4MzgyNTYwLWIxMTMyNWI4NWE2YTk3NGRjZGJhMjUzNmJhMjg1MDQ3OTEzNDE5NGY4MWFhMjRlYWU4MmE3ZGQyOGU4N2YwMzY)
 
 
-- [武汉新型冠状病毒防疫信息收集平台](#%e6%ad%a6%e6%b1%89%e6%96%b0%e5%9e%8b%e5%86%a0%e7%8a%b6%e7%97%85%e6%af%92%e9%98%b2%e7%96%ab%e4%bf%a1%e6%81%af%e6%94%b6%e9%9b%86%e5%b9%b3%e5%8f%b0)
+- [新型冠状病毒肺炎防疫信息收集平台](#%e6%ad%a6%e6%b1%89%e6%96%b0%e5%9e%8b%e5%86%a0%e7%8a%b6%e7%97%85%e6%af%92%e9%98%b2%e7%96%ab%e4%bf%a1%e6%81%af%e6%94%b6%e9%9b%86%e5%b9%b3%e5%8f%b0)
   - [协作流程](#%e5%8d%8f%e4%bd%9c%e6%b5%81%e7%a8%8b)
   - [该平台主要开源项目](#%e8%af%a5%e5%b9%b3%e5%8f%b0%e4%b8%bb%e8%a6%81%e5%bc%80%e6%ba%90%e9%a1%b9%e7%9b%ae)
     - [数据同步](#%e6%95%b0%e6%8d%ae%e5%90%8c%e6%ad%a5)
@@ -22,7 +22,7 @@
   - [Slack频道导航](#slack%e9%a2%91%e9%81%93%e5%af%bc%e8%88%aa)
 - [FAQ常见问题 （持续更新，招募志愿者一起维护）](#faq%e5%b8%b8%e8%a7%81%e9%97%ae%e9%a2%98-%e6%8c%81%e7%bb%ad%e6%9b%b4%e6%96%b0%e6%8b%9b%e5%8b%9f%e5%bf%97%e6%84%bf%e8%80%85%e4%b8%80%e8%b5%b7%e7%bb%b4%e6%8a%a4)
 
-# 武汉新型冠状病毒防疫信息收集平台
+# 新型冠状病毒肺炎防疫信息收集平台
 
 针对 2020 年初在武汉爆发的新型冠状病毒疫情，本项目旨在收集各医院、酒店、工厂、物流、捐赠、捐款、预防、治疗、动态等信息，统一收集，统一发布，以便各方之间进行信息互通，有效调配社会资源。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -5,7 +5,7 @@
 
 ### Volunteer entrance         >>> [![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](https://join.slack.com/t/wuhan2020/shared_invite/enQtOTQxMTU4MzgyNTYwLWIxMTMyNWI4NWE2YTk3NGRjZGJhMjUzNmJhMjg1MDQ3OTEzNDE5NGY4MWFhMjRlYWU4MmE3ZGQyOGU4N2YwMzY)
 
-- [Information Collection Platform for Wuhan Covid-19 Epidemic Prevention](#information-collection-platform-for-wuhan-Covid-19-epidemic-prevention)
+- [Information Collection Platform for Covid-19 Epidemic Prevention](#information-collection-platform-for-wuhan-Covid-19-epidemic-prevention)
   - [Collaboration process](#collaboration-process)
   - [Major Open Source Sub-Projects](#major-open-source-sub-projects)
     - [Data Synchronization](#data-synchronization)
@@ -20,7 +20,7 @@
 - [Slack Communication Group](#slack-communication-group)
   - [Slack Channel Navigation](#slack-channel-navigation)
 
-# Information Collection Platform for Wuhan Covid-19 Epidemic Prevention
+# Information Collection Platform for Covid-19 Epidemic Prevention
 This translation updates to 18:30(CST), 1/30/2020.
 
 This project aims at collecting and gathering information of hospitals, hotels, factories, logistics, donations, contributions, prevention, treatment and any live information regarding national epidemic prevention from reliable sources to help all affected people, organizations better communicate and coordinate with each other to efficiently and effectively fight against the Novel Coronavirus (Covid-19) outbreak that started in Wuhan, Hubei, China. All of the code will be open-source and the data collected will be carefully reviewed/validated and available to the public.


### PR DESCRIPTION
使用了国家卫生健康委官方用命，避免疾病或病毒名中出现“武汉”字样，带来歧视风险。
官方通知如下：
http://www.gov.cn/zhengce/zhengceku/2020-02/22/content_5482019.htm